### PR TITLE
Handle auto-generated source files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,25 @@
 Get the "last updated" time for each Sphinx page from Git
 =========================================================
 
-This is a little Sphinx_ extension that does just that.
+This is a little Sphinx_ extension that does exactly that.
 
-It also checks for included files.
+It also checks for included files and other dependencies.
 
-If a page doesn't have a source file (or if Git is broken or whatever),
-its last_updated_ time is set to ``None``.
+If a page doesn't have a source file, its last_updated_ time is set to ``None``.
 
-The default value for html_last_updated_fmt_ is changed to the empty string.
+If a source file is not tracked by Git (e.g. because it has been auto-generated
+on demand by autosummary_generate_) but its dependencies are, the last_updated_
+time is taken from them.  If you don't want this to happen, use
+``git_untracked_check_dependencies = False``.
+
+If a source file is not tracked by Git, its HTML page doesn't get a source link.
+If you do want those pages to have a sourcelink, set
+``git_untracked_show_sourcelink = True``.  Of course, in this case
+html_copy_source_ and html_show_sourcelink_ must also be ``True``,
+and the theme you are using must support source links in the first place.
+
+The default value for html_last_updated_fmt_ is changed
+from ``None`` to the empty string.
 
 Usage
     #. Install the Python package ``sphinx-last-updated-by-git``
@@ -41,6 +52,12 @@ Similar stuff
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _last_updated: https://www.sphinx-doc.org/en/master/
     templating.html#last_updated
+.. _autosummary_generate: https://www.sphinx-doc.org/en/master/
+    usage/extensions/autosummary.html#confval-autosummary_generate
+.. _html_copy_source: https://www.sphinx-doc.org/en/master/
+    usage/configuration.html#confval-html_copy_source
+.. _html_show_sourcelink: https://www.sphinx-doc.org/en/master/
+    usage/configuration.html#confval-html_show_sourcelink
 .. _html_last_updated_fmt: https://www.sphinx-doc.org/en/master/
     usage/configuration.html#confval-html_last_updated_fmt
 .. _DONT_SHALLOW_CLONE: https://read-the-docs.readthedocs.io/en/latest/


### PR DESCRIPTION
Those files exist locally in the source directory, therefore Sphinx defines `sourcename`. However, they cannot be found in the Git repo, so we cannot reasonably set the "last modified" time.

In addition, we un-define `sourcename` in order to manipulate HTML templates into thinking that there is no source file available, which should disable source links in most themes. If this behavior is not wanted, source links can be re-enabled with:

```python
sphinx_last_updated_by_git_affects_sourcename = False
```

UPDATE: I changed the name of the config value and added another one.