### PR TITLE
Use srcdir instead of confdir when looking up files

### DIFF
--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -58,7 +58,7 @@ def _html_page_context(app, pagename, templatename, context, doctree):
         # This happens in 'singlehtml' builders
         assert context['sourcename'] == ''
         return
-    sourcefile = Path(app.confdir, pagename + context['page_source_suffix'])
+    sourcefile = Path(app.srcdir, pagename + context['page_source_suffix'])
     dates = []
     try:
         dates.append(get_datetime(
@@ -78,7 +78,7 @@ def _html_page_context(app, pagename, templatename, context, doctree):
 
     # Check dependencies (if they are in a Git repo)
     for dep in app.env.dependencies[pagename]:
-        path = Path(app.confdir, dep)
+        path = Path(app.srcdir, dep)
         try:
             date = get_datetime(path, app.config.git_last_updated_timezone)
         except Exception:


### PR DESCRIPTION
This allows the extension to look up the path of files if their path doesn't
start at the same directory path as where the Sphinx configuration file is
placed.