### PR TITLE
Refactor to use fewer git calls

### DIFF
--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -1,12 +1,13 @@
 """Get the "last updated" time for each Sphinx page from Git."""
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 import subprocess
 
-import sphinx.errors
 from sphinx.locale import _
 from sphinx.util.i18n import format_date
 from sphinx.util.logging import getLogger
+from sphinx.util import status_iterator
 
 
 __version__ = '0.2.4'
@@ -15,38 +16,177 @@ __version__ = '0.2.4'
 logger = getLogger(__name__)
 
 
-class NotInRepository(Exception):
-    """The file is not in a Git repo."""
+def update_file_dates(git_dir, file_dates):
+    """Ask Git for "author time" of given files in given directory.
+
+    A git subprocess is executed at most three times:
+
+    * First, to check which of the files are even managed by Git.
+    * With only those files (if any), a "git log" is created and parsed
+      until all requested files have been found.
+    * If the root commit is reached (i.e. there is at least one of the
+      requested files that has never been edited since the root commit),
+      git is called again to check whether the repo is "shallow".
+
+    """
+    requested_files = set(file_dates)
+    assert requested_files
+
+    existing_files = subprocess.check_output(
+        [
+            'git', 'ls-files', '-z', '--', *requested_files
+        ],
+        cwd=git_dir,
+        stderr=subprocess.PIPE,
+    ).rstrip().rstrip(b'\0')
+    if not existing_files:
+        return  # None of the requested files are under version control
+    existing_files = existing_files.decode('utf-8').split('\0')
+    requested_files.intersection_update(existing_files)
+    assert requested_files
+
+    process = subprocess.Popen(
+        [
+            'git', 'log', '--pretty=format:%n%at%x00%P', '--author-date-order',
+            '--relative', '--name-only', '-z', '-m', '--', *requested_files
+        ],
+        cwd=git_dir,
+        stdout=subprocess.PIPE,
+        # NB: We ignore stderr to avoid deadlocks when reading stdout
+    )
+
+    requested_files = set(f.encode('utf-8') for f in requested_files)
+
+    # First line is blank
+    line0 = process.stdout.readline().rstrip()
+    assert not line0, 'unexpected git output in {}: {}'.format(git_dir, line0)
+
+    while requested_files:
+        line1 = process.stdout.readline()
+        assert line1, 'end of git log in {}, unhandled files: {}'.format(
+            git_dir, requested_files)
+        timestamp, null, parent_commits = line1.rstrip().partition(b'\0')
+        assert null == b'\0', 'invalid git info in {}: {}'.format(
+            git_dir, line1)
+        line2 = process.stdout.readline().rstrip()
+        assert line2.endswith(b'\0'), 'unexpected file list in {}: {}'.format(
+            git_dir, line2)
+        line2 = line2.rstrip(b'\0')
+        assert line2, 'no changed files in {} (parent commit(s): {})'.format(
+            git_dir, parent_commits)
+        changed_files = line2.split(b'\0')
+
+        too_shallow = False
+        if not parent_commits:
+            is_shallow = subprocess.check_output(
+                # --is-shallow-repository is available since Git 2.15.
+                ['git', 'rev-parse', '--is-shallow-repository'],
+                cwd=git_dir,
+                stderr=subprocess.PIPE,
+            ).rstrip()
+            if is_shallow == b'true':
+                too_shallow = True
+
+        for file in changed_files:
+            try:
+                requested_files.remove(file)
+            except KeyError:
+                continue
+            else:
+                file_dates[file.decode('utf-8')] = timestamp, too_shallow
+
+        assert parent_commits or not requested_files, (
+            'unexpected root commit in {}'.format(git_dir))
+
+    # We found all requested files in the log, we don't need the rest of it:
+    process.terminate()
 
 
-class TooShallow(Exception):
-    """The file was last updated in the initial commit of a shallow clone."""
+def _env_updated(app, env):
+    # NB: We call git once per sub-directory, because each one could
+    #     potentially be a separate Git repo (or at least a submodule)!
 
+    src_paths = {}
+    src_dates = defaultdict(dict)
 
-def get_datetime(path, tz):
-    """Obtain the "author time" for *path* from Git."""
-    path = Path(path)
+    for docname, data in env.git_last_updated.items():
+        if data is not None:
+            continue  # No need to update this source file
+        srcfile = Path(env.doc2path(docname)).resolve()
+        src_dates[srcfile.parent][srcfile.name] = None
+        src_paths[docname] = srcfile.parent, srcfile.name
 
-    def run_command(cmd):
-        return subprocess.check_output(
-            cmd,
-            cwd=path.parent,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-        )
+    srcdir_iter = status_iterator(
+        src_dates, 'getting Git timestamps for source files... ',
+        'fuchsia', len(src_dates))
+    for git_dir in srcdir_iter:
+        try:
+            update_file_dates(git_dir, src_dates[git_dir])
+        except subprocess.CalledProcessError as e:
+            msg = 'Error getting data from Git'
+            msg += ' (no "last updated" dates will be shown'
+            msg += ' for source files from {})'.format(git_dir)
+            if e.stderr:
+                msg += ':\n' + e.stderr.decode('utf-8')
+            logger.warning(msg, type='git', subtype='subprocess_error')
+        except FileNotFoundError as e:
+            logger.warning(
+                '"git" command not found, '
+                'no "last updated" dates will be shown',
+                type='git', subtype='command_not_found')
+            return
 
-    result = run_command(
-        ['git', 'log', '-n1', '--pretty=tformat:%at%n%P', '--', path.name])
-    if not result:
-        raise NotInRepository(path)
-    timestamp, parents = result.splitlines()
-    if not parents:
-        # --is-shallow-repository is available since Git 2.15.
-        result = run_command(['git', 'rev-parse', '--is-shallow-repository'])
-        if result.rstrip('\n') == 'true':
-            raise TooShallow(path)
-    utc_time = datetime.fromtimestamp(int(timestamp), timezone.utc)
-    return utc_time.astimezone(tz)
+    dep_paths = defaultdict(list)
+    dep_dates = defaultdict(dict)
+
+    candi_dates = defaultdict(list)
+    show_sourcelink = {}
+
+    for docname, (src_dir, filename) in src_paths.items():
+        show_sourcelink[docname] = True
+        date = src_dates[src_dir][filename]
+        if date is None:
+            if not app.config.git_untracked_show_sourcelink:
+                show_sourcelink[docname] = False
+            if not app.config.git_untracked_check_dependencies:
+                continue
+        else:
+            candi_dates[docname].append(date)
+        for dep in env.dependencies[docname]:
+            # NB: dependencies are relative to srcdir and may contain ".."!
+            depfile = Path(env.srcdir, dep).resolve()
+            dep_dates[depfile.parent][depfile.name] = None
+            dep_paths[docname].append((depfile.parent, depfile.name))
+
+    depdir_iter = status_iterator(
+        dep_dates, 'getting Git timestamps for dependencies... ',
+        'turquoise', len(dep_dates))
+    for git_dir in depdir_iter:
+        try:
+            update_file_dates(git_dir, dep_dates[git_dir])
+        except subprocess.CalledProcessError as e:
+            pass  # We ignore errors in dependencies
+
+    for docname, deps in dep_paths.items():
+        for dep_dir, filename in deps:
+            date = dep_dates[dep_dir][filename]
+            if date is None:
+                continue
+            candi_dates[docname].append(date)
+
+    for docname in src_paths:
+        timestamps = candi_dates[docname]
+        if timestamps:
+            # NB: too_shallow is only relevant if it affects the latest date.
+            timestamp, too_shallow = max(timestamps)
+            if too_shallow:
+                timestamp = None
+                logger.warning(
+                    'Git clone too shallow', location=docname,
+                    type='git', subtype='too_shallow')
+        else:
+            timestamp = None
+        env.git_last_updated[docname] = timestamp, show_sourcelink[docname]
 
 
 def _html_page_context(app, pagename, templatename, context, doctree):
@@ -58,44 +198,21 @@ def _html_page_context(app, pagename, templatename, context, doctree):
         # This happens in 'singlehtml' builders
         assert context['sourcename'] == ''
         return
-    sourcefile = Path(app.srcdir, pagename + context['page_source_suffix'])
-    dates = []
-    try:
-        dates.append(get_datetime(
-            sourcefile, app.config.git_last_updated_timezone))
-    except subprocess.CalledProcessError as e:
-        raise sphinx.errors.ExtensionError(
-            'Error getting data from Git:\n' + e.stderr, e)
-    except FileNotFoundError as e:
-        raise sphinx.errors.ExtensionError('"git" command not found', e)
-    except NotInRepository:
-        if not app.config.git_untracked_show_sourcelink:
-            del context['sourcename']
-        if not app.config.git_untracked_check_dependencies:
-            return
-        shallow = False
-    except TooShallow:
-        shallow = True
 
-    # Check dependencies (if they are in a Git repo)
-    for dep in app.env.dependencies[pagename]:
-        path = Path(app.srcdir, dep)
-        try:
-            date = get_datetime(path, app.config.git_last_updated_timezone)
-        except Exception:
-            continue
-        else:
-            dates.append(date)
-
-    if not dates:
-        if shallow:
-            logger.warning(
-                'Git clone too shallow', location=pagename,
-                type='git', subtype='too_shallow')
+    data = app.env.git_last_updated[pagename]
+    if data is None:
+        # There was a problem with git, a warning has already been issued
+        timestamp = None
+        show_sourcelink = False
+    else:
+        timestamp, show_sourcelink = data
+    if not show_sourcelink:
+        del context['sourcename']
+    if timestamp is None:
         return
 
-    date = max(dates)
-
+    utc_date = datetime.fromtimestamp(int(timestamp), timezone.utc)
+    date = utc_date.astimezone(app.config.git_last_updated_timezone)
     context['last_updated'] = format_date(
         lufmt or _('%b %d, %Y'),
         date=date,
@@ -116,20 +233,49 @@ def _config_inited(app, config):
             config.git_last_updated_timezone)
 
 
+def _builder_inited(app):
+    env = app.env
+    if not hasattr(env, 'git_last_updated'):
+        env.git_last_updated = {}
+
+
+def _source_read(app, docname, source):
+    env = app.env
+    assert docname not in env.git_last_updated
+    env.git_last_updated[docname] = None
+
+
+def _env_merge_info(app, env, docnames, other):
+    env.git_last_updated.update(other.git_last_updated)
+
+
+def _env_purge_doc(app, env, docname):
+    try:
+        del env.git_last_updated[docname]
+    except KeyError:
+        pass
+
+
 def setup(app):
     """Sphinx extension entry point."""
     app.require_sphinx('1.8')  # For "config-inited" event
     app.connect('html-page-context', _html_page_context)
     app.connect('config-inited', _config_inited)
+    app.connect('env-updated', _env_updated)
+    app.connect('builder-inited', _builder_inited)
+    app.connect('source-read', _source_read)
+    app.connect('env-merge-info', _env_merge_info)
+    app.connect('env-purge-doc', _env_purge_doc)
     app.add_config_value(
-        'git_untracked_check_dependencies', True, rebuild='html')
+        'git_untracked_check_dependencies', True, rebuild='env')
     app.add_config_value(
-        'git_untracked_show_sourcelink', False, rebuild='html')
+        'git_untracked_show_sourcelink', False, rebuild='env')
     app.add_config_value(
-        'git_last_updated_timezone', None, rebuild='html')
+        'git_last_updated_timezone', None, rebuild='env')
     app.add_config_value(
         'git_last_updated_metatags', True, rebuild='html')
     return {
         'version': __version__,
         'parallel_read_safe': True,
+        'env_version': 1,
     }

--- a/tests/test_example_repo.py
+++ b/tests/test_example_repo.py
@@ -32,7 +32,7 @@ expected_results = {
 def run_sphinx(subdir, **kwargs):
     srcdir = Path(__file__).parent / subdir
     with tempfile.TemporaryDirectory() as outdir:
-        args = [str(srcdir), outdir, '-W']
+        args = [str(srcdir), outdir, '-W', '-v']
         args.extend('-D{}={}'.format(k, v) for k, v in kwargs.items())
         result = build_main(args)
         assert result == 0

--- a/tests/test_example_repo.py
+++ b/tests/test_example_repo.py
@@ -110,3 +110,16 @@ def test_no_git(capsys):
         assert '"git" command not found' in capsys.readouterr().err
     finally:
         os.environ['PATH'] = path_backup
+
+
+def test_no_git_no_warning(capsys):
+    path_backup = os.environ['PATH']
+    os.environ['PATH'] = ''
+    try:
+        data = run_sphinx(
+            'repo_full',
+            suppress_warnings='git.command_not_found')
+    finally:
+        os.environ['PATH'] = path_backup
+    for k, v in data.items():
+        assert v == ['None', 'undefined']

--- a/tests/test_singlehtml.py
+++ b/tests/test_singlehtml.py
@@ -7,7 +7,7 @@ from sphinx.cmd.build import build_main
 def test_singlehtml():
     srcdir = Path(__file__).parent / 'repo_full'
     with tempfile.TemporaryDirectory() as outdir:
-        args = [str(srcdir), outdir, '-W', '-b', 'singlehtml']
+        args = [str(srcdir), outdir, '-W', '-v', '-b', 'singlehtml']
         result = build_main(args)
         assert result == 0
         path = Path(outdir) / 'index.html'

--- a/tests/test_untracked.py
+++ b/tests/test_untracked.py
@@ -6,7 +6,7 @@ import pytest
 from sphinx.cmd.build import build_main
 
 
-def create_and_run(srcdir):
+def create_and_run(srcdir, **kwargs):
     srcdir = Path(srcdir)
     srcdir.joinpath('conf.py').write_text("""
 extensions = [
@@ -26,7 +26,9 @@ This will be an untracked dependency.
 {% if sourcename is not defined %}un{% endif %}defined
 """)
     outdir = srcdir / '_build'
-    result = build_main([str(srcdir), str(outdir), '-W', '-v'])
+    args = [str(srcdir), str(outdir), '-W', '-v']
+    args.extend('-D{}={}'.format(k, v) for k, v in kwargs.items())
+    result = build_main(args)
     if result != 0:
         return None
     path = outdir / 'index.html'
@@ -37,6 +39,12 @@ def test_without_git_repo(capsys):
     with tempfile.TemporaryDirectory() as srcdir:
         assert create_and_run(srcdir) is None
         assert 'Error getting data from Git' in capsys.readouterr().err
+
+
+def test_without_git_repo_without_warning():
+    with tempfile.TemporaryDirectory() as srcdir:
+        data = create_and_run(srcdir, suppress_warnings='git.subprocess_error')
+    assert data == ['None', 'undefined']
 
 
 def test_untracked_source_files():

--- a/tests/test_untracked.py
+++ b/tests/test_untracked.py
@@ -26,7 +26,7 @@ This will be an untracked dependency.
 {% if sourcename is not defined %}un{% endif %}defined
 """)
     outdir = srcdir / '_build'
-    result = build_main([str(srcdir), str(outdir), '-W'])
+    result = build_main([str(srcdir), str(outdir), '-W', '-v'])
     if result != 0:
         return None
     path = outdir / 'index.html'


### PR DESCRIPTION
Instead of calling `git` one or two times *per file*, now it is called up to six times *per directory*.

It is called per directory because potentially, every directory could be a separate Git repository. This is probably not very common, but it is possible.

Source files and their dependencies are checked in separate `git` calls, because checking dependencies might not be necessary depending on the `git_untracked_check_dependencies` setting.
Also, I have the feeling that parsing of very long logs is on average faster if done on subsets of the requested files. I don't know if that is meaningful compared to the `subprocess` overhead, though.

Anyway, for small projects this shouldn't make a big difference, but I hope it will make a substantial difference for huge projects.