### PR TITLE
Handle "added" but not yet "committed" files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@ Get the "last updated" time for each Sphinx page from Git
 This is a little Sphinx_ extension that does exactly that.
 It also checks for included files and other dependencies and
 uses their "last updated" time if it's more recent.
+For each file, the "author date" of the Git commit where it was last changed
+is taken to be its "last updated" time.  Uncommitted changes are ignored.
 
 If a page doesn't have a source file, its last_updated_ time is set to ``None``.
 

--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -17,7 +17,7 @@ logger = getLogger(__name__)
 
 
 def update_file_dates(git_dir, file_dates):
-    """Ask Git for "author time" of given files in given directory.
+    """Ask Git for "author date" of given files in given directory.
 
     A git subprocess is executed at most three times:
 


### PR DESCRIPTION
This is an alternative to #30, where the first check is moved out of the `while` loop.