### PR TITLE
CI: Disable Python 3.6 on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: "3.6"
+          - os: windows-latest
+            python-version: "3.6"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This seems to be not supported anymore.