### PR TITLE
Separate parse_log() function for use in "with" statement

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = --cov --cov-report term --cov-report html
+filterwarnings =
+    error
+    default:unable to set time zone:UserWarning


### PR DESCRIPTION
This way, the subprocess is always closed, even in case of an error.

Not doing this isn't a big deal, but it caused warnings to be displayed. And I think we should try to not cause any warnings in the automated tests. This should also make it easier for downstream packages to turn on warnings.