### PR TITLE
Add exclude_commits feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,10 @@ Options
       These patterns are checked on both source files and dependencies
       and are treated the same way as Sphinx's exclude_patterns_.
 
+    * Individual commits can be excluded from the last updated date
+      calculation by passing a list of commit hashes to the configuration
+      option ``git_exclude_commits``.
+
 Caveats
     * When using a "Git shallow clone" (with the ``--depth`` option),
       the "last updated" commit for a long-unchanged file

--- a/tests/test_example_repo.py
+++ b/tests/test_example_repo.py
@@ -160,3 +160,33 @@ def test_exclude_patterns_deps_dates():
         'api': [time1, 'defined'],
         'example_module.example_function': ['None', 'undefined'],
     }
+
+
+def test_exclude_commits_dates():
+    data = run_sphinx(
+        'repo_full',
+        git_exclude_commits='6bb90c6027c3788d3891f833f017dbf8d229e432')
+    assert data == {
+        **expected_results,
+        'api': [time1, 'defined'],
+        'example_module.example_function': [time1, 'undefined'],
+    }
+
+
+def test_exclude_commits_warning(capsys):
+    with pytest.raises(AssertionError):
+        run_sphinx(
+            'repo_full',
+            git_exclude_commits='23d25d0b7ac4604b7a9545420b2f9de84daabe73')
+    assert 'unhandled files' in capsys.readouterr().err
+
+
+def test_exclude_commits_without_warning():
+    data = run_sphinx(
+        'repo_full',
+        suppress_warnings='git.unhandled_files',
+        git_exclude_commits='23d25d0b7ac4604b7a9545420b2f9de84daabe73')
+    assert data == {
+        **expected_results,
+        'I 🖤 Unicode': ['None', 'undefined'],
+    }


### PR DESCRIPTION
I added an "ignored hashes" feature. This is useful to ignore some cosmetic-only changes in the "last updated date", for instance when rewrapping source files. This is similar to [the `ignore-rev` feature](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt) of `git blame`.

Individual commits can now be ignored using the `git_ignored_hashes` config key. This key is defined with a list of hashes strings to ignore. This list is then converted into a set of UTF-8 encoded binary objects to optimize the lookup.

If a commit matches this set, then it is skipped. This can lead to unhandled files, thus the assert is converted into a warning.

I had to add a new parameter to each functions as I didn't want to add a global variable. Using a class could have been useful in this case in order to add `ignored_hashes` into a shared state.

I'm not sure about the `rebuild` value of the config value and the name of the config key could be changed to `git_ignore_hashes`.

P.S. I will add documentation for this option soon.
