### PR TITLE
Add exclude_patterns feature based on sphinx Matcher

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,8 @@ Options
     * Files can be excluded from the last updated date calculation by passing
       a list of exclusion patterns to the configuration option
       ``git_exclude_patterns``.
-      This can also be used to ignore the changes of dependencies in the last
-      updated date.
-      The patterns are treated the same way as Sphinx's exclude_patterns_.
+      These patterns are checked on both source files and dependencies
+      and are treated the same way as Sphinx's exclude_patterns_.
 
 Caveats
     * When using a "Git shallow clone" (with the ``--depth`` option),

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Options
       ``git_exclude_patterns``.
       This can also be used to ignore the changes of dependencies in the last
       updated date.
-      The patterns are treated the same way as Sphinx's excluded_patterns_.
+      The patterns are treated the same way as Sphinx's exclude_patterns_.
 
 Caveats
     * When using a "Git shallow clone" (with the ``--depth`` option),

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,13 @@ Options
       tag.  This can be disabled by setting the configuration option
       ``git_last_updated_metatags`` to ``False``.
 
+    * Files can be excluded from the last updated date calculation by passing
+      a list of exclusion patterns to the configuration option
+      ``git_exclude_patterns``.
+      This can also be used to ignore the changes of dependencies in the last
+      updated date.
+      The patterns are treated the same way as Sphinx's excluded_patterns_.
+
 Caveats
     * When using a "Git shallow clone" (with the ``--depth`` option),
       the "last updated" commit for a long-unchanged file
@@ -82,6 +89,8 @@ Similar stuff
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _last_updated: https://www.sphinx-doc.org/en/master/
     templating.html#last_updated
+.. _exclude_patterns: https://www.sphinx-doc.org/en/master/usage/
+    configuration.html#confval-exclude_patterns
 .. _autosummary_generate: https://www.sphinx-doc.org/en/master/
     usage/extensions/autosummary.html#confval-autosummary_generate
 .. _html_copy_source: https://www.sphinx-doc.org/en/master/

--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -2,14 +2,13 @@
 from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime, timezone
-from fnmatch import fnmatch
 from pathlib import Path
-from typing import List
 import subprocess
 
 from sphinx.locale import _
 from sphinx.util.i18n import format_date
 from sphinx.util.logging import getLogger
+from sphinx.util.matching import Matcher
 from sphinx.util import status_iterator
 
 
@@ -117,14 +116,6 @@ def parse_log(stream, requested_files, git_dir, file_dates):
             break
 
 
-def is_file_ignored(file: Path, ignored_files: List[str]) -> bool:
-    """Check if a file matches a list of ignored files using fnmatch"""
-    for ignored_file in ignored_files:
-        if fnmatch(str(file), ignored_file):
-            return True
-    return False
-
-
 def _env_updated(app, env):
     # NB: We call git once per sub-directory, because each one could
     #     potentially be a separate Git repo (or at least a submodule)!
@@ -136,13 +127,14 @@ def _env_updated(app, env):
 
     src_paths = {}
     src_dates = defaultdict(dict)
+    excluded = Matcher(app.config.git_exclude_patterns)
 
     for docname, data in env.git_last_updated.items():
         if data is not None:
             continue  # No need to update this source file
-        srcfile = Path(env.doc2path(docname)).resolve()
-        if is_file_ignored(srcfile, app.config.git_ignored_files):
+        if excluded(env.doc2path(docname, False)):
             continue
+        srcfile = Path(env.doc2path(docname)).resolve()
         src_dates[srcfile.parent][srcfile.name] = None
         src_paths[docname] = srcfile.parent, srcfile.name
 
@@ -184,9 +176,9 @@ def _env_updated(app, env):
             candi_dates[docname].append(date)
         for dep in env.dependencies[docname]:
             # NB: dependencies are relative to srcdir and may contain ".."!
-            depfile = Path(env.srcdir, dep).resolve()
-            if is_file_ignored(depfile, app.config.git_ignored_files):
+            if excluded(dep):
                 continue
+            depfile = Path(env.srcdir, dep).resolve()
             dep_dates[depfile.parent][depfile.name] = None
             dep_paths[docname].append((depfile.parent, depfile.name))
 
@@ -307,7 +299,7 @@ def setup(app):
         'git_last_updated_timezone', None, rebuild='env')
     app.add_config_value(
         'git_last_updated_metatags', True, rebuild='html')
-    app.add_config_value('git_ignored_files', [], rebuild='env')
+    app.add_config_value('git_exclude_patterns', [], rebuild='env')
     return {
         'version': __version__,
         'parallel_read_safe': True,

--- a/tests/test_example_repo.py
+++ b/tests/test_example_repo.py
@@ -139,7 +139,7 @@ def test_exclude_patterns_srcdir_relative():
 def test_exclude_patterns_glob():
     data = run_sphinx(
         'repo_full',
-        git_exclude_patterns='**/*.rst',
+        git_exclude_patterns='*.rst',
     )
     assert data == {
         **expected_results,
@@ -153,7 +153,7 @@ def test_exclude_patterns_glob():
 def test_exclude_patterns_deps_dates():
     data = run_sphinx(
         'repo_full',
-        git_exclude_patterns='*.py',
+        git_exclude_patterns='example_module.py',
     )
     assert data == {
         **expected_results,

--- a/tests/test_example_repo.py
+++ b/tests/test_example_repo.py
@@ -123,3 +123,40 @@ def test_no_git_no_warning(capsys):
         os.environ['PATH'] = path_backup
     for k, v in data.items():
         assert v == ['None', 'undefined']
+
+
+def test_exclude_patterns_srcdir_relative():
+    data = run_sphinx(
+        'repo_full',
+        git_exclude_patterns='I 🖤 Unicode.rst',
+    )
+    assert data == {
+        **expected_results,
+        'I 🖤 Unicode': ['None', 'undefined'],
+    }
+
+
+def test_exclude_patterns_glob():
+    data = run_sphinx(
+        'repo_full',
+        git_exclude_patterns='**/*.rst',
+    )
+    assert data == {
+        **expected_results,
+        'index': ['None', 'undefined'],
+        'I 🖤 Unicode': ['None', 'undefined'],
+        'api': ['None', 'undefined'],
+        'example_module.example_function': ['None', 'undefined'],
+    }
+
+
+def test_exclude_patterns_deps_dates():
+    data = run_sphinx(
+        'repo_full',
+        git_exclude_patterns='*.py',
+    )
+    assert data == {
+        **expected_results,
+        'api': [time1, 'defined'],
+        'example_module.example_function': ['None', 'undefined'],
+    }


### PR DESCRIPTION
Another option similar to #41 to ignore some changes in dates. This is especially useful for ignoring files in dependencies. This way the date does not change if an ignored dependent file is updated.

My current use case would be to ignore the `docutils.conf` file, as I it is added as a dependency by Sphinx to all documents, but I only want to reflect content changes in the "last updated date".
The current implementation uses [`fnmatch`](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch) so some kinds of wildcard patterns are accepted. In my case I would use the following in `conf.py`:

```py
git_ignored_files = [
    '*/docutils.conf',
]
```

As for #41, the name of the config key can be changed, and docs will follow after a first review of the patch, just to see if you are willing to accept these changes.