### PR TITLE
TST: temporarily require Sphinx 4.5.0 to avoid a Sphinx regression

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
+sphinx==4.5.0  # temporary, see https://github.com/mgeier/sphinx-last-updated-by-git/issues/40
 pytest
 pytest-cov


### PR DESCRIPTION
This should be reverted once #40 is solved.