### PR TITLE
TST: add test case for too_shallow warning

### DIFF
--- a/tests/test_example_repo.py
+++ b/tests/test_example_repo.py
@@ -82,7 +82,13 @@ def test_untracked_no_dependencies_and_show_sourcelink():
     }
 
 
-def test_repo_shallow():
+def test_repo_shallow(capsys):
+    with pytest.raises(AssertionError):
+        run_sphinx('repo_shallow')
+    assert 'too shallow' in capsys.readouterr().err
+
+
+def test_repo_shallow_without_warning():
     data = run_sphinx(
         'repo_shallow',
         suppress_warnings='git.too_shallow,',


### PR DESCRIPTION
There was already a test suppressing `git.too_shallow`, but now I'm adding a test that checks if the warning is even raised when not suppressing it.