### PR TITLE
Ignore added but uncommited files from the beginning

### DIFF
--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -35,7 +35,8 @@ def update_file_dates(git_dir, file_dates):
 
     existing_files = subprocess.check_output(
         [
-            'git', 'ls-files', '-z', '--', *requested_files
+            'git', 'ls-tree', '--name-only', '-z', 'HEAD',
+            '--', *requested_files
         ],
         cwd=git_dir,
         stderr=subprocess.PIPE,
@@ -66,10 +67,6 @@ def parse_log(stream, requested_files, git_dir, file_dates):
     requested_files = set(f.encode('utf-8') for f in requested_files)
 
     line0 = stream.readline()
-    if not line0:
-        logger.info('added but uncommitted file(s) in {}: {}'.format(
-            git_dir, {f.decode('utf-8') for f in requested_files}))
-        return
 
     # First line is blank
     assert not line0.rstrip(), 'unexpected git output in {}: {}'.format(
@@ -108,11 +105,6 @@ def parse_log(stream, requested_files, git_dir, file_dates):
                 continue
             else:
                 file_dates[file.decode('utf-8')] = timestamp, too_shallow
-
-        if requested_files and not parent_commits:
-            logger.info('added but uncommitted file(s) in {}: {}'.format(
-                git_dir, {f.decode('utf-8') for f in requested_files}))
-            break
 
 
 def _env_updated(app, env):


### PR DESCRIPTION
Since "added but uncommited" files are _in fine_ completely ignored, I would suggest to ignore them from the beginning by applying this patch.

With [`git ls-tree HEAD`](https://git-scm.com/docs/git-ls-tree) only commited files are listed. So there is no need for both the checks removed. I tested it by manually adding files to the staged area but it would be good to have a test for this.

With this patch, The only way that the parsing loop can go out of lines is here:
https://github.com/mgeier/sphinx-last-updated-by-git/blob/69dbf2c91cedec1465e9aad868b49e0e6d30fe31/src/sphinx_last_updated_by_git.py#L80-L88

EDIT:
There might be problem with removing the first if block seeing that #31 introduced an independent `if` for a completely empty git output. Maybe it should be turned into an assert.

_Originally posted by @n-peugnet in https://github.com/mgeier/sphinx-last-updated-by-git/pull/41#discussion_r958301792_

EDIT2:
Just for the record:

```console
$ touch tests/repo_full/test
$ git -C tests/repo_full/ add test
$ git -C tests/repo_full/ status 
HEAD detached at 23d25d0
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	new file:   test

$ git -C tests/repo_full/ ls-files -- _templates/layout.html api.rst test
_templates/layout.html
api.rst
test
$ git -C tests/repo_full/ ls-tree --name-only HEAD -- _templates/layout.html api.rst test
_templates/layout.html
api.rst
```
