### PR TITLE
TST: Exclude Sphinx 5.0.x and 5.1.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,13 +79,11 @@ Caveats
 
       See also `issue #1`_.
 
-    * Starting with Sphinx version 5.0, there has been a
-      (most likely unintentional) change in how dependencies are determined.
-      This may lead to spurious dependencies which means that some
-      "last changed" dates might be wrong.
-      This will hopefully be fixed in a future Sphinx version.
-      In the meantime, Sphinx version 4.5.0  (with docutils 0.17.1)
-      can be used.
+    * In Sphinx versions 5.0 and 5.1, there has been
+      a regression in how dependencies are determined.
+      This could lead to spurious dependencies
+      which means that some "last changed" dates were wrong.
+      This has been fixed in Sphinx version 5.2 and above.
 
       See also `issue #40`_.
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==4.5.0  # temporary, see https://github.com/mgeier/sphinx-last-updated-by-git/issues/40
+sphinx != 5.0.*, != 5.1.*
 pytest
 pytest-cov


### PR DESCRIPTION
In 5.2.0 the dependency problem will be fixed, see https://github.com/sphinx-doc/sphinx/pull/10855

Closes #40.