### PR TITLE
Avoid warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
       run: |
         python tests/update_submodules.py
     - name: Install Python package
+      env:
+        # See https://github.com/pypa/wheel/issues/507:
+        PYTHONWARNINGS: error,ignore:pkg_resources is deprecated:DeprecationWarning
       run: |
         python -m pip install .
     - name: Install test dependencies

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
+from pathlib import Path
+
 from setuptools import setup
+
 
 # "import" __version__
 __version__ = 'unknown'
-for line in open('src/sphinx_last_updated_by_git.py'):
-    if line.startswith('__version__'):
-        exec(line)
-        break
+with Path('src/sphinx_last_updated_by_git.py').open() as f:
+    for line in f:
+        if line.startswith('__version__'):
+            exec(line)
+            break
 
 setup(
     name='sphinx-last-updated-by-git',
@@ -19,7 +23,7 @@ setup(
     author='Matthias Geier',
     author_email='Matthias.Geier@gmail.com',
     description='Get the "last updated" time for each Sphinx page from Git',
-    long_description=open('README.rst').read(),
+    long_description=Path('README.rst').read_text(),
     license='BSD-2-Clause',
     keywords='Sphinx Git'.split(),
     url='https://github.com/mgeier/sphinx-last-updated-by-git/',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 sphinx != 5.0.*, != 5.1.*
 pytest
 pytest-cov
+tzdata; sys_platform == "win32" and python_version >= "3.9"


### PR DESCRIPTION
There's still an error on Windows (Python 3.10):

    ModuleNotFoundError: No module named 'tzdata'