### PR TITLE
Support "source-read" being emitted for included docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,10 @@ Caveats
 
       See also `issue #1`_.
 
+    * A regression in Sphinx version 7.2 prevents the extension from working
+      properly when using the ``.. include`` directive. See `Sphinx issue
+      #11643`_.
+
     * In Sphinx versions 5.0 and 5.1, there has been
       a regression in how dependencies are determined.
       This could lead to spurious dependencies
@@ -117,3 +121,4 @@ Similar stuff
     guides/feature-flags.html
 .. _issue #1: https://github.com/mgeier/sphinx-last-updated-by-git/issues/1
 .. _issue #40: https://github.com/mgeier/sphinx-last-updated-by-git/issues/40
+.. _Sphinx issue #11643: https://github.com/sphinx-doc/sphinx/issues/11643

--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -276,8 +276,10 @@ def _builder_inited(app):
 
 def _source_read(app, docname, source):
     env = app.env
-    assert docname not in env.git_last_updated
-    env.git_last_updated[docname] = None
+    # Since Sphinx 7.2, the source-read hook can be called multiple times
+    # when using .. include
+    if docname not in env.git_last_updated:
+        env.git_last_updated[docname] = None
 
 
 def _env_merge_info(app, env, docnames, other):


### PR DESCRIPTION
Since Sphinx 7.2, the "source-read" event is emitted for included documents (.. include directive). A document can be included multiple times, and thus the hook cannot assume that it's called only once per docname.

An issue in Sphinx itself affects the extension when using included documents. Add a warning in the README.