### PR TITLE
CI: Don't turn DeprecationWarning into an error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,12 @@ jobs:
         python tests/update_submodules.py
     - name: Install Python package
       env:
-        # See https://github.com/pypa/wheel/issues/507:
-        PYTHONWARNINGS: error,ignore:pkg_resources is deprecated:DeprecationWarning
+        PYTHONWARNINGS: error,default::DeprecationWarning
       run: |
         python -m pip install .
     - name: Install test dependencies
+      env:
+        PYTHONWARNINGS: error,default::DeprecationWarning
       run: |
         python -m pip install -r tests/requirements.txt
     - name: Run pytest


### PR DESCRIPTION
I originally wanted to filter for individual warning messages, but this happens too often in 3rd party dependencies.