### PR TITLE
Allow docname to be None in source-read event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,12 @@ jobs:
         python tests/update_submodules.py
     - name: Install Python package
       env:
-        # See https://github.com/pypa/wheel/issues/507:
-        PYTHONWARNINGS: error,ignore:pkg_resources is deprecated:DeprecationWarning
+        PYTHONWARNINGS: error,default::DeprecationWarning
       run: |
         python -m pip install .
     - name: Install test dependencies
+      env:
+        PYTHONWARNINGS: error,default::DeprecationWarning
       run: |
         python -m pip install -r tests/requirements.txt
     - name: Run pytest

--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -275,6 +275,9 @@ def _builder_inited(app):
 
 
 def _source_read(app, docname, source):
+    if docname is None:
+        # This may happen since Sphinx 7.2.0?
+        return
     env = app.env
     assert docname not in env.git_last_updated
     env.git_last_updated[docname] = None


### PR DESCRIPTION
I don't know why that happens, but it seems to happen since Sphinx 7.2, most likely since https://github.com/sphinx-doc/sphinx/pull/11510.

This has also been reported in https://github.com/sphinx-doc/sphinx/issues/11620, but it has been closed.