### PR TITLE
Ignore missing dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,13 @@ Caveats
 
           suppress_warnings = ['git.too_shallow']
 
+    * If depedency file does not exist, a warning is being emitted.
+
+      If you only want to get rid of the warning (without actually fixing the problem),
+      use this in your ``conf.py``::
+
+          suppress_warnings = ['git.dependency_not_found']
+
     * When a project on https://readthedocs.org/ using their default theme
       ``sphinx_rtd_theme`` was created before October 20th 2020,
       the date will not be displayed in the footer.

--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -189,6 +189,15 @@ def _env_updated(app, env):
             if excluded(dep):
                 continue
             depfile = Path(env.srcdir, dep).resolve()
+            if not depfile.exists():
+                logger.warning(
+                    "Dependency file %r, doesn't exist, skipping",
+                    depfile,
+                    location=docname,
+                    type='git',
+                    subtype='dependency_not_found',
+                )
+                continue
             dep_dates[depfile.parent][depfile.name] = None
             dep_paths[docname].append((depfile.parent, depfile.name))
 


### PR DESCRIPTION
I have a README file which includes image from `docs/_static` folder:
https://github.com/MobileTeleSystems/onetl/blob/develop/README.rst?plain=1#L28

And I also include this file in `docs/index.rst` file of my documentation:
https://github.com/MobileTeleSystems/onetl/blob/06b561a7a7e642893c1feb500109a83de741207c/docs/index.rst?plain=1#L1-L2

This leads to including file with path `docs/docs/_static` because Sphinx does resolve file paths only after the entire content is being included. Fortunately, Sphinx just ignores missing files, and I can use a small hack to include this image to `docs/index.rst` (see file below).

Unfortunately, this extension expects all the files from directives, like an image above, to exist. When `git ls-tree` receives a file which does not exist, it fails with a message like this:
```
Extension error (sphinx_last_updated_by_git):
Handler <function _env_updated at 0x7daaea7b4e00> for event 'env-updated' threw an exception (exception: [Errno 2] No such file or directory: PosixPath('/home/maxim/Repo/onetl/docs/docs/_static'))
```

I've added a small check that dependency should exist, to avoid such an issue.