### PR TITLE
Remove line 262

### DIFF
--- a/src/sphinx_last_updated_by_git.py
+++ b/src/sphinx_last_updated_by_git.py
@@ -259,7 +259,6 @@ def _html_page_context(app, pagename, templatename, context, doctree):
     else:
         timestamp, show_sourcelink = data
     if not show_sourcelink:
-        del context['sourcename']
         del context['page_source_suffix']
     if timestamp is None:
         return


### PR DESCRIPTION
This pull request makes a minor adjustment to the handling of page context in the Sphinx extension. Specifically, it stops deleting the `sourcename` key from the `context` dictionary when the source link should not be shown, but continues to remove `page_source_suffix` as before.

- No longer deletes the `sourcename` key from the `context` dictionary when `show_sourcelink` is false in the `_html_page_context` function in `sphinx_last_updated_by_git.py`.

Closes #103.